### PR TITLE
修复语音接口 br 压缩解码失败导致的获取异常

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from astrbot.api.event import filter, AstrMessageEvent
 import aiohttp
 import tempfile
 import os
+import brotli
 
 
 @register("zhiyu-astrbot-hjm", "知鱼", "一款随机哈基米语音的AstrBot插件", "2.0")
@@ -15,18 +16,28 @@ class MyPlugin(Star):
     async def wsde_handler(self, message: AstrMessageEvent):
         temp_path = None
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(self.api_url) as response:
+            headers = {"Accept-Encoding": "identity"}
+            async with aiohttp.ClientSession(auto_decompress=False) as session:
+                async with session.get(self.api_url, headers=headers) as response:
                     if response.status == 200:
-                        with tempfile.NamedTemporaryFile(delete=False, suffix='.mp3') as temp_file:
+                        with tempfile.NamedTemporaryFile(
+                            delete=False, suffix=".mp3"
+                        ) as temp_file:
                             temp_path = temp_file.name
                             audio_content = await response.read()
+                            if (
+                                response.headers.get("Content-Encoding", "").lower()
+                                == "br"
+                            ):
+                                audio_content = brotli.decompress(audio_content)
                             temp_file.write(audio_content)
-                        
+
                         chain = [Record.fromFileSystem(temp_path)]
                         yield message.chain_result(chain)
                     else:
-                        yield message.plain_result("获取哈基米语音失败 请稍后重试")
+                        yield message.plain_result(
+                            f"获取哈基米语音失败（HTTP {response.status}）请稍后重试"
+                        )
         except Exception as e:
             yield message.plain_result(f"获取语音时出错：{str(e)}")
         finally:


### PR DESCRIPTION
<img width="486" height="200" alt="image" src="https://github.com/user-attachments/assets/b1404fd4-18bc-4784-aa86-8500b6f8b110" />

在语音请求中显式添加 Accept-Encoding: identity，尽量避免服务端返回 br 压缩

将 aiohttp.ClientSession 设置为 auto_decompress=False，避免自动解压链路不一致导致报错

当响应头为 Content-Encoding: br 时，增加 brotli.decompress 手动解压兜底

非 200 响应时返回 HTTP 状态码，便于线上排查问题